### PR TITLE
fix static controller test bug

### DIFF
--- a/test/integration/user_does_not_see_inactive_causes_test.rb
+++ b/test/integration/user_does_not_see_inactive_causes_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 
 class UserDoesNotSeeInactiveCausesTest < ActionDispatch::IntegrationTest
-  test "visit and user do not see another user's inactive causes" do
+  test "visitor and user do not see another user's inactive causes" do
+    featured_cause_user!
+    create_featured_causes!
     user1 = users(:carl)
     user2 = users(:bernie)
     cause = causes(:bad_idea)


### PR DESCRIPTION
Since the home page is now always looking for the mike dao featured user causes, those files from the test helper had to be run in a test that loads the home page. 
