### PR TITLE
User deletes account

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,8 +53,14 @@ class ApplicationController < ActionController::Base
   def backfill_causes(user)
     causes = Cause.where(user_id: user.id)
     holder = User.find_by(email: "gone@heaven.com")
-    causes.each { |cause| cause.update_column(:user_id, holder.id) }
-    causes.each { |cause| backfill_donations(cause) }
+    causes.each { |cause| package_cause_for_death(cause, holder) }
+  end
+
+  def package_cause_for_death(cause, holder)
+    backfill_donations(cause)
+    cause.update_column(:user_id, holder.id)
+    cause.update_column(:current_status, "deleted")
+    # cause.delete
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,4 +44,17 @@ class ApplicationController < ActionController::Base
     params[:user].to_i == current_user_id
   end
 
+  def backfill_donations(cause)
+    donations = Donation.where(cause_id: cause.id)
+    holder = Cause.find_by(title: "Dead Dream")
+    donations.each {|donation| donation.update_column(:cause_id, holder.id)}
+  end
+
+  def backfill_causes(user)
+    causes = Cause.where(user_id: user.id)
+    holder = User.find_by(email: "gone@heaven.com")
+    causes.each { |cause| cause.update_column(:user_id, holder.id) }
+    causes.each { |cause| backfill_donations(cause) }
+  end
+
 end

--- a/app/controllers/users/causes_controller.rb
+++ b/app/controllers/users/causes_controller.rb
@@ -42,9 +42,7 @@ class Users::CausesController < ApplicationController
 
   def destroy
     cause = Cause.find(params[:id])
-    donation = Donation.find_by(cause_id: cause.id)
-    holder = Cause.find_by(title: "Dead Dream")
-    donation.update_column(:cause_id, holder.id)
+    backfill_donations(cause)
     cause.delete
     redirect_to user_path(User.find(params[:user]))
   end

--- a/app/controllers/users/causes_controller.rb
+++ b/app/controllers/users/causes_controller.rb
@@ -27,11 +27,11 @@ class Users::CausesController < ApplicationController
   end
 
   def edit
-    @cause = Cause.find(params[:id])
+    @cause = current_user.causes.find(params[:id])
   end
 
   def update
-    @cause = Cause.find(params[:id])
+    @cause = current_user.causes.find(params[:id])
     update_cause_attribues
     if URI(request.referrer).path == admin_dashboard_path
       redirect_to admin_dashboard_path
@@ -41,7 +41,7 @@ class Users::CausesController < ApplicationController
   end
 
   def destroy
-    cause = Cause.find(params[:id])
+    cause = current_user.causes.find(params[:id])
     backfill_donations(cause)
     cause.delete
     redirect_to user_path(User.find(params[:user]))

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    user = User.find(params[:id])
+    user = current_user
     holder = User.find_by(email: "gone@heaven.com")
     backfill_causes(user)
     user.delete

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :user_exists?, only: [:show]
   before_action :valid_user?, only: [:edit, :update]
 
   def new
@@ -34,6 +35,15 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    user = User.find(params[:id])
+    holder = User.find_by(email: "gone@heaven.com")
+    backfill_causes(user)
+    user.delete
+    session.clear
+    redirect_to root_path
+  end
+
   private
 
   def redirect_back_or(default)
@@ -47,5 +57,9 @@ class UsersController < ApplicationController
   def valid_user?
     user = User.find(params[:id])
     redirect_to root_path unless current_user_id == user.id
+  end
+
+  def user_exists?
+    redirect_to root_path unless (User.all.pluck(:id).include?(params[:id].to_i))
   end
 end

--- a/app/views/users/causes/show.html.erb
+++ b/app/views/users/causes/show.html.erb
@@ -1,6 +1,6 @@
 <% unless @cause.current_status == 'active' %>
   <span>
-    <h5><%= @cause.title %> is currently <%= @cause.current_status %>!</h5>
+    <h5 id="cause-status"><%= @cause.title %> is currently <%= @cause.current_status %>!</h5>
   </span>
 <% end %>
 <div class="container">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -20,4 +20,7 @@
 
     <%= f.submit "Update Account", class: "wave-effect waves-light btn light-green darken-4" %>
   <% end  %>
+  <% if current_user_id == @user.id %>
+    <%= link_to "Delete Account", user_path(@user), method: :delete, class: "btn red right" %>
+  <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   resources :donations, only: [:create]
   resources :categories, only: [:index, :show]
-  resources :users, only: [:new, :create, :edit, :update, :show]
+  resources :users, only: [:new, :create, :edit, :update, :show, :destroy]
 
   namespace :users, path: ':user', as: :user do
     resources :causes

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,6 +7,7 @@ class Seed
     generate_pending_causes
     generate_specific_users
     featured_cause_user
+    deleted_user_placeholder
     deleted_cause_placeholder
     moon
     potato
@@ -99,9 +100,17 @@ class Seed
     description: "Dream, dream, little angel",
     image_url: Faker::Avatar.image,
     goal: 0,
-    user_id: User.find_by(email: "mike_dao@dreambuilder.com").id,
+    user_id: User.find_by(email: "gone@heaven.com").id,
     category_id: 1,
     current_status: 'active'
+    )
+  end
+
+  def deleted_user_placeholder
+    user = User.create!(
+    username: "Dead Person",
+    email: "gone@heaven.com",
+    password_digest: User.digest('password')
     )
   end
 

--- a/test/fixtures/donations.yml
+++ b/test/fixtures/donations.yml
@@ -3,3 +3,9 @@ first:
   cause_id: 1
   cause_name: colonize_moon
   amount: 100
+
+first:
+  user_id: 2
+  cause_id: 1
+  cause_name: colonize_moon
+  amount: 44

--- a/test/integration/user_can_delete_account_test.rb
+++ b/test/integration/user_can_delete_account_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class UserCanDeleteAccountTest < ActionDispatch::IntegrationTest
+  test "the truth" do
+    featured_cause_user!
+    create_featured_causes!
+    user = users(:carl)
+    log_in(user)
+
+    visit edit_user_path(user)
+    click_on "Delete Account"
+    visit user_path(user)
+    assert_equal root_path, current_path
+  end
+end

--- a/test/integration/user_can_delete_account_test.rb
+++ b/test/integration/user_can_delete_account_test.rb
@@ -8,14 +8,33 @@ class UserCanDeleteAccountTest < ActionDispatch::IntegrationTest
     create_featured_causes!
   end
 
-  test "the truth" do
+  test "users can delete their causes" do
     user = users(:carl)
     log_in(user)
 
     visit edit_user_path(user)
     click_on "Delete Account"
     visit "/users/1"
-    
+
     assert_equal root_path, current_path
+  end
+
+  test "donation history still exists after cause deletion" do
+    user = users(:carl)
+    log_in(user)
+    cause = user.causes.first
+    donation_id = cause.donations.first.id
+
+    visit edit_user_path(user)
+    assert_equal "Automatic Dispensing Cereal Machine", cause.title
+    click_on "Delete Account"
+
+    assert_equal root_path, current_path
+
+    donation =  Donation.find(donation_id)
+    assert donation
+
+    cause = Cause.find(donation.cause_id)
+    assert_equal "Dead Dream", cause.title
   end
 end

--- a/test/integration/user_can_delete_account_test.rb
+++ b/test/integration/user_can_delete_account_test.rb
@@ -29,12 +29,23 @@ class UserCanDeleteAccountTest < ActionDispatch::IntegrationTest
     assert_equal "Automatic Dispensing Cereal Machine", cause.title
     click_on "Delete Account"
 
-    assert_equal root_path, current_path
-
     donation =  Donation.find(donation_id)
     assert donation
 
     cause = Cause.find(donation.cause_id)
     assert_equal "Dead Dream", cause.title
+  end
+
+  test "causes not associated with user after deletion" do
+    user = users(:carl)
+    log_in(user)
+    cause_id = user.causes.first.id
+
+    visit edit_user_path(user)
+
+    click_on "Delete Account"
+
+    cause = Cause.find(cause_id)
+    assert_equal "Dead Person", cause.user.username
   end
 end

--- a/test/integration/user_can_delete_account_test.rb
+++ b/test/integration/user_can_delete_account_test.rb
@@ -1,15 +1,21 @@
 require 'test_helper'
 
 class UserCanDeleteAccountTest < ActionDispatch::IntegrationTest
-  test "the truth" do
+  def setup
     featured_cause_user!
+    deleted_user_placeholder
+    deleted_cause_placeholder
     create_featured_causes!
+  end
+
+  test "the truth" do
     user = users(:carl)
     log_in(user)
 
     visit edit_user_path(user)
     click_on "Delete Account"
-    visit user_path(user)
+    visit "/users/1"
+    
     assert_equal root_path, current_path
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,22 +36,6 @@ module ActionDispatch
       click_on "Log Out"
     end
 
-    def create_eight_orders_for_user
-      user = create(:user)
-      staches = create_list(:stache, 3)
-      orders = create_list(:order, 8)
-      quantities = (1..5).to_a
-
-      orders.each do |order|
-        staches.each do |stache|
-          order.order_staches.create(stache_id: stache.id,
-                                     quantity: quantities.sample)
-        end
-      end
-
-      user.orders << orders
-    end
-
     def featured_cause_user!
       User.create!(
       username:     'mike_dao',
@@ -69,6 +53,14 @@ module ActionDispatch
       user_id: User.find_by(email: "mike_dao@dreambuilder.com").id,
       category_id: 1,
       current_status: 'active'
+      )
+    end
+
+    def deleted_user_placeholder
+      user = User.create!(
+      username: "Dead Person",
+      email: "gone@heaven.com",
+      password_digest: User.digest('password')
       )
     end
 


### PR DESCRIPTION
-this allows for users to delete their accounts, but before a user can be deleted, their associated causes (and the donations associated with each cause) have to be reassigned to something, or there are foreign key errors.  So now users can be deleted, and their causes could be wiped totally out, but for now I kept their causes reassigned to a place holder user so that the platform admin really has access to the site's history. But if we later decide to fully delete causes, we just need to change like 2 lines of code.  
closes #65 
